### PR TITLE
Require Node.js 6 and bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -27,7 +27,7 @@
 	],
 	"dependencies": {
 		"app-path": "^2.1.0",
-		"plist": "^2.0.1"
+		"plist": "^3.0.1"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
this resolves a vulnerability with snyk

```
Testing /Users/jdickey/src/github.com/sindresorhus/iterm2-version...
✗ Low severity vulnerability found on plist@2.1.0
- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:plist:20180219
- from: iterm2-version@2.3.0 > plist@2.1.0
Upgrade direct dependency plist@2.1.0 to plist@3.0.1

Organisation: dickeyxxx
Package manager: yarn
Target file: package.json
Open source: no

Tested 82 dependencies for known vulnerabilities, found 1 vulnerability, 1 vulnerable path.
```